### PR TITLE
アカウント管理画面・ログアウト機能を追加

### DIFF
--- a/TrainingQiitaApp/AccountMenuView.swift
+++ b/TrainingQiitaApp/AccountMenuView.swift
@@ -1,0 +1,81 @@
+//
+//  AccountMenuView.swift
+//  TrainingQiitaApp
+//
+//  Created by  hayato on 2025/04/18.
+//
+
+import SwiftUI
+
+struct AccountMenuView: View {
+    @ObservedObject var viewModel: LoginViewModel
+    
+    @State private var showLogoutAlert = false
+    var onClose: () -> Void
+    
+    var body: some View {
+        if viewModel.user != nil {
+            NavigationStack {
+                VStack(spacing: 20) {
+        
+                    if let urlString = viewModel.user?.profileImageUrl,
+                       let url = URL(string: urlString) {
+                        AsyncImage(url: url) { image in
+                            image
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 80, height: 80)
+                                .clipShape(Circle())
+                        } placeholder: {
+                            ProgressView()
+                                .frame(width: 80, height: 80)
+                        }
+                    }
+                    
+                    VStack(spacing: 4) {
+                        Text(viewModel.user?.name ?? "")
+                            .font(.title)
+                            .fontWeight(.medium)
+                        
+                        Text(viewModel.user?.id ?? "")
+                            .font(.subheadline)
+                            .foregroundColor(.gray)
+                    }
+                    
+                    Button("ログアウト") {
+                        showLogoutAlert = true
+                    }
+                    .foregroundColor(.red)
+                    .padding(.top, 20)
+                    
+                    Spacer()
+                }
+                .padding()
+                .frame(maxWidth: .infinity)
+                .background(Color(.systemBackground))
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button("戻る") {
+                            onClose()
+                        }
+                        .foregroundColor(.white)
+                    }
+                }
+                .navigationTitle("アカウント")
+                .navigationBarTitleDisplayMode(.inline)
+                .alert("ログアウトしますか？", isPresented: $showLogoutAlert) {
+                    Button("キャンセル", role: .cancel) {}
+                    Button("ログアウト", role: .destructive) {
+                        viewModel.user = nil
+                        viewModel.accessToken = ""
+                        viewModel.loginStatus = .idle
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+   // AccountMenuView()
+}

--- a/TrainingQiitaApp/AccountMenuView.swift
+++ b/TrainingQiitaApp/AccountMenuView.swift
@@ -66,16 +66,10 @@ struct AccountMenuView: View {
                 .alert("ログアウトしますか？", isPresented: $showLogoutAlert) {
                     Button("キャンセル", role: .cancel) {}
                     Button("ログアウト", role: .destructive) {
-                        viewModel.user = nil
-                        viewModel.accessToken = ""
-                        viewModel.loginStatus = .idle
+                        viewModel.logout()
                     }
                 }
             }
         }
     }
-}
-
-#Preview {
-   // AccountMenuView()
 }

--- a/TrainingQiitaApp/HomeView.swift
+++ b/TrainingQiitaApp/HomeView.swift
@@ -11,6 +11,8 @@ struct HomeView: View {
     @ObservedObject var viewModel: LoginViewModel
     @StateObject private var searchViewModel = ArticlesSearchViewModel()
     
+    @State private var isAccountMenuPresented = false
+    
     var body: some View {
         NavigationStack {
             VStack {
@@ -44,13 +46,13 @@ struct HomeView: View {
                     ProgressView("読み込み中...")
                         .padding()
                 }
-
+                
                 if let error = viewModel.errorMessage {
                     Text(error)
                         .foregroundColor(.red)
                         .padding(.bottom, 8)
                 }
-
+                
                 List(searchViewModel.articles) { article in
                     NavigationLink(destination: ArticleDetailView(title: article.title,parsedBody: article.parsedBody)) {
                         VStack(alignment: .leading, spacing: 4) {
@@ -67,11 +69,6 @@ struct HomeView: View {
                 
                 Spacer()
                 
-                Button("ログアウト") {
-                    viewModel.loginStatus = .idle
-                    viewModel.accessToken = ""
-                    viewModel.user = nil
-                }
             }
             .padding()
             .navigationTitle("Qiita")
@@ -86,13 +83,34 @@ struct HomeView: View {
                                 .scaledToFill()
                                 .frame(width: 32, height: 32)
                                 .clipShape(Circle())
+                                .onTapGesture {
+                                    isAccountMenuPresented = true
+                                }
                         } placeholder: {
                             ProgressView()
+                                .frame(width: 32, height: 32)
+                                .onTapGesture {
+                                    isAccountMenuPresented = true
+                                }
                         }
+                    } else {
+                        Image(systemName: "person.circle.fill")
+                            .resizable()
+                            .frame(width: 32, height: 32)
+                            .clipShape(Circle())
+                            .onTapGesture {
+                                isAccountMenuPresented = true
+                            }
                     }
                 }
             }
+            .fullScreenCover(isPresented: $isAccountMenuPresented) {
+                AccountMenuView(viewModel: viewModel){
+                    isAccountMenuPresented = false
+                }
+            }
         }
+        
     }
 }
 

--- a/TrainingQiitaApp/LoginViewModel.swift
+++ b/TrainingQiitaApp/LoginViewModel.swift
@@ -55,4 +55,11 @@ class LoginViewModel: ObservableObject {
             }
         }
     }
+    
+    func logout() {
+        self.user = nil
+        self.accessToken = ""
+        self.loginStatus = .idle
+    }
+    
 }


### PR DESCRIPTION
## 概要
アカウント管理画面・ログアウト機能を追加

## 修正点
ホーム画面（記事検索画面）にて、左上のアカウントアイコンを押すことでアカウント管理画面に遷移し、そこからログアウトを行えるようにした

## スクリーンショット
### ホーム画面
![Simulator Screenshot - iPhone 16 Pro - 2025-04-22 at 17 50 01](https://github.com/user-attachments/assets/02939d86-7abf-4aa2-a688-a349eb7748fe)

### アカウント管理画面
![Simulator Screenshot - iPhone 16 Pro - 2025-04-22 at 17 50 14](https://github.com/user-attachments/assets/3dd49a2a-4401-4d94-a3ca-582dd358aba9)

### ログアウトボタン押下時
![Simulator Screenshot - iPhone 16 Pro - 2025-04-22 at 17 50 20](https://github.com/user-attachments/assets/4f73f6cb-b69e-4928-8630-0dc28bf8fe1a)

## 動作確認
シミューレージョン上で正しく動作するかを確認した

## 確認してほしい箇所
上記が問題なく動作するか
