### PR TITLE
ログインボタンの動作の修正

### DIFF
--- a/TrainingQiitaApp/LoginView.swift
+++ b/TrainingQiitaApp/LoginView.swift
@@ -9,45 +9,47 @@ import SwiftUI
 
 struct LoginView: View {
     @ObservedObject var viewModel: LoginViewModel
-
-        var body: some View {
-            VStack(spacing: 24) {
-                Text("Qiitaへログイン")
-                    .font(.largeTitle)
-                    .fontWeight(.bold)
-
-                TextField("アクセストークンを入力", text: $viewModel.accessToken)
-                    .textFieldStyle(RoundedBorderTextFieldStyle())
-                    .padding(.horizontal)
-                    .autocapitalization(.none)
-                    .disableAutocorrection(true)
-
-                Button("ログイン") {
-                    viewModel.login()
-                }
-                .frame(maxWidth: .infinity)
-                .padding()
-                .background(Color.green)
-                .foregroundColor(.white)
-                .cornerRadius(8)
+    
+    @State private var showAlert = false
+    
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("Qiitaへログイン")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+            
+            TextField("アクセストークンを入力", text: $viewModel.accessToken)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
                 .padding(.horizontal)
-
-                // ログイン状態に応じた表示
-                if viewModel.loginStatus == .loading {
-                    ProgressView()
-                } else if viewModel.loginStatus == .failure {
-                    Text(viewModel.errorMessage ?? "エラーが発生しました")
-                        .foregroundColor(.red)
-                } else if viewModel.loginStatus == .success {
-                    Text("ログイン成功！\(viewModel.user?.name ?? "不明")")
-                        .foregroundColor(.blue)
-                } else {
-                    Text(" ")
-                        .frame(maxWidth: .infinity)
-                }
+                .autocapitalization(.none)
+                .disableAutocorrection(true)
+            
+            Button("ログイン") {
+                viewModel.login()
             }
+            .frame(maxWidth: .infinity)
             .padding()
-        }}
+            .disabled(viewModel.loginStatus != .idle)
+            .background(viewModel.loginStatus == .idle ? .green : .gray)
+            .foregroundColor(.white)
+            .cornerRadius(8)
+            .padding(.horizontal)
+        }
+        .padding()
+        .onChange(of: viewModel.loginStatus) {
+            if viewModel.loginStatus == .failure {
+                showAlert = true
+            }
+        }
+        .alert("エラー", isPresented: $showAlert) {
+            Button("OK") {
+                viewModel.loginStatusReset()
+            }
+        } message: {
+            Text(viewModel.errorMessage ?? "エラーが発生しました")
+        }
+    }
+}
 
 #Preview {
     LoginView(viewModel: LoginViewModel())

--- a/TrainingQiitaApp/LoginView.swift
+++ b/TrainingQiitaApp/LoginView.swift
@@ -37,9 +37,7 @@ struct LoginView: View {
         }
         .padding()
         .onChange(of: viewModel.loginStatus) {
-            if viewModel.loginStatus == .failure {
-                showAlert = true
-            }
+            showAlert = viewModel.loginStatus == .failure
         }
         .alert("エラー", isPresented: $showAlert) {
             Button("OK") {

--- a/TrainingQiitaApp/LoginViewModel.swift
+++ b/TrainingQiitaApp/LoginViewModel.swift
@@ -62,4 +62,8 @@ class LoginViewModel: ObservableObject {
         self.loginStatus = .idle
     }
     
+    func loginStatusReset() {
+        self.loginStatus = .idle
+    }
+    
 }


### PR DESCRIPTION
## 概要
ログインボタンの動作の修正

## 修正点
ログインボタンをViewModelのloginStatsuが.idle以外の状態の時には押せないように修正した
エラーが起きた際にアラート表示でエラー文を表示できるようにした

## スクリーンショット
![Simulator Screenshot - iPhone 16 Pro - 2025-04-25 at 14 11 58](https://github.com/user-attachments/assets/57b31e6d-2084-41ac-a848-8f1e13f4d2d5)


## 動作確認
シミュレータ上で起動し、正しく動くかを確認した

## 確認してほしい箇所
コードの記述法に問題がないか
